### PR TITLE
Attach award id in messaging extension

### DIFF
--- a/Source/Microsoft.Teams.Apps.RewardAndRecognition/Helpers/CardHelper.cs
+++ b/Source/Microsoft.Teams.Apps.RewardAndRecognition/Helpers/CardHelper.cs
@@ -130,6 +130,28 @@ namespace Microsoft.Teams.Apps.RewardAndRecognition.Helpers
         }
 
         /// <summary>
+        /// Get task module response for error message when bot is invoked from 1:1 chat or group chat on messaging extension action response.
+        /// </summary>
+        /// <param name="localizer">The current cultures' string localizer.</param>
+        /// <returns>Returns task module response.</returns>
+        public static MessagingExtensionActionResponse GetTaskModuleErrorMessageCard(IStringLocalizer<Strings> localizer)
+        {
+            return new MessagingExtensionActionResponse
+            {
+                Task = new TaskModuleContinueResponse
+                {
+                    Value = new TaskModuleTaskInfo
+                    {
+                        Card = ValidationMessageCard.GetErrorAdaptiveCard(localizer.GetString("MessagingExtensionErrorMessage")),
+                        Height = ErrorMessageTaskModuleHeight,
+                        Width = ErrorMessageTaskModuleWidth,
+                        Title = localizer.GetString("NominatePeopleTitle"),
+                    },
+                },
+            };
+        }
+
+        /// <summary>
         /// Get task endorsement task module response.
         /// </summary>
         /// <param name="applicationBasePath">Represents the Application base Uri.</param>

--- a/Source/Microsoft.Teams.Apps.RewardAndRecognition/Helpers/SearchHelper.cs
+++ b/Source/Microsoft.Teams.Apps.RewardAndRecognition/Helpers/SearchHelper.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Teams.Apps.RewardAndRecognition.Helpers
     using System.Globalization;
     using System.Linq;
     using System.Threading.Tasks;
+    using System.Web;
     using AdaptiveCards;
     using Microsoft.Bot.Schema;
     using Microsoft.Bot.Schema.Teams;
@@ -169,8 +170,8 @@ namespace Microsoft.Teams.Apps.RewardAndRecognition.Helpers
 
                     ThumbnailCard previewCard = new ThumbnailCard
                     {
-                        Title = nominatedDetail.NomineeNames,
-                        Subtitle = $"<p style='font-weight: 600;'>{nominatedDetail.AwardName}</p>",
+                        Title = HttpUtility.HtmlEncode(nominatedDetail.NomineeNames),
+                        Subtitle = $"<p style='font-weight: 600;'>{HttpUtility.HtmlEncode(nominatedDetail.AwardName)}</p>",
                     };
 
                     composeExtensionResult.Attachments.Add(new Attachment

--- a/Source/Microsoft.Teams.Apps.RewardAndRecognition/Helpers/SearchHelper.cs
+++ b/Source/Microsoft.Teams.Apps.RewardAndRecognition/Helpers/SearchHelper.cs
@@ -158,6 +158,7 @@ namespace Microsoft.Teams.Apps.RewardAndRecognition.Helpers
                                     Command = Constants.EndorseAction,
                                     NomineeUserPrincipalNames = nominatedDetail.NomineeUserPrincipalNames,
                                     AwardName = nominatedDetail.AwardName,
+                                    AwardId = nominatedDetail.AwardId,
                                     NomineeNames = nominatedDetail.NomineeNames,
                                     NomineeObjectIds = nominatedDetail.NomineeObjectIds,
                                     RewardCycleId = nominatedDetail.RewardCycleId,
@@ -169,7 +170,7 @@ namespace Microsoft.Teams.Apps.RewardAndRecognition.Helpers
                     ThumbnailCard previewCard = new ThumbnailCard
                     {
                         Title = nominatedDetail.NomineeNames,
-                        Subtitle = nominatedDetail.AwardName,
+                        Subtitle = $"<p style='font-weight: 600;'>{nominatedDetail.AwardName}</p>",
                     };
 
                     composeExtensionResult.Attachments.Add(new Attachment

--- a/Source/Microsoft.Teams.Apps.RewardAndRecognition/Microsoft.Teams.Apps.RewardAndRecognition.csproj
+++ b/Source/Microsoft.Teams.Apps.RewardAndRecognition/Microsoft.Teams.Apps.RewardAndRecognition.csproj
@@ -43,7 +43,7 @@
   </PropertyGroup>
   <ItemGroup>
     <AdditionalFiles Include="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), .gitignore))\Build\stylecop.json" />
-  </ItemGroup>  
+  </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources\Strings.Designer.cs">
       <DesignTime>True</DesignTime>

--- a/Source/Microsoft.Teams.Apps.RewardAndRecognition/Resources/Strings.Designer.cs
+++ b/Source/Microsoft.Teams.Apps.RewardAndRecognition/Resources/Strings.Designer.cs
@@ -196,6 +196,15 @@ namespace Microsoft.Teams.Apps.RewardAndRecognition {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This app not available in 1:1 or group chats. To send an award, navigate to a team where Workplace Awards has been added..
+        /// </summary>
+        public static string MessagingExtensionErrorMessage {
+            get {
+                return ResourceManager.GetString("MessagingExtensionErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to * Approve and publish the award winners from the list of nominees..
         /// </summary>
         public static string NominateBulletPoint {

--- a/Source/Microsoft.Teams.Apps.RewardAndRecognition/Resources/Strings.resx
+++ b/Source/Microsoft.Teams.Apps.RewardAndRecognition/Resources/Strings.resx
@@ -278,4 +278,8 @@
     <value>Unexpected tenant id found.</value>
     <comment>Unexpected tenant id found.</comment>
   </data>
+  <data name="MessagingExtensionErrorMessage" xml:space="preserve">
+    <value>This app not available in 1:1 or group chats. To send an award, navigate to a team where Workplace Awards has been added.</value>
+    <comment>Message to be shown when bot invoked from 1:1 or group chat</comment>
+  </data>
 </root>


### PR DESCRIPTION
[Fix] - AwardId is not binded with the messaging extension attachment card, which leads to multiple endorsement when invoked from ME. The change is added in SearchHelper class to add AwardId property.