### PR TITLE
Update ARM deployment and manifest file

### DIFF
--- a/Deployment/azuredeploy.json
+++ b/Deployment/azuredeploy.json
@@ -62,7 +62,7 @@
     "appIconUrl": {
       "type": "string",
       "minLength": 1,
-      "defaultValue": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-apps-workplaceawards/master/Manifest/color.pn",
+      "defaultValue": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-apps-workplaceawards/master/Manifest/color.png",
       "metadata": {
         "description": "The link to the icon for the app. It must resolve to a PNG file."
       }

--- a/Deployment/azuredeploy.json
+++ b/Deployment/azuredeploy.json
@@ -24,14 +24,6 @@
         "description": "The client secret of the bot Azure AD app."
       }
     },
-    "appClientId": {
-      "type": "string",
-      "minLength": 36,
-      "maxLength": 36,
-      "metadata": {
-        "description": "The client ID of the app Azure AD app, e.g., 123e4567-e89b-12d3-a456-426655440000."
-      }
-    },
     "appDisplayName": {
       "type": "string",
       "minLength": 1,
@@ -296,7 +288,7 @@
             },
             {
               "name": "AzureAd:ClientId",
-              "value": "[parameters('appclientId')]"
+              "value": "[parameters('botClientId')]"
             },
             {
               "name": "AzureAd:ApplicationIdURI",

--- a/Manifest/manifest.json
+++ b/Manifest/manifest.json
@@ -24,7 +24,7 @@
   "accentColor": "#00B764",
   "bots": [
     {
-      "botId": "",
+      "botId": "<<botId>>",
       "scopes": [
         "team"
       ],
@@ -80,7 +80,7 @@
     "<<appDomain>>"
   ],
   "webApplicationInfo": {
-    "id": "<Application client id>",
-    "resource": "<Application URI>"
+    "id": "<<botId>>",
+    "resource": "api://<<applicationurl>>/<<botId>>"
   }
 }


### PR DESCRIPTION
[Fix] - fixing the typo in ARM deployment file for app icon URL. The image is used to set up as bot icon during resource creation and failure to do so shows the default image.
[Fix] - updated files to ease the deployment steps by using common names across manifest file and revised the deployment guide accordingly. 